### PR TITLE
Bundle HTML+PDF in BRZ2 envelope; resume layout + print rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@
 /static/handwriting/
 /static/me.png
 /static/me-shocked.png
-/static/encrypted-resumes/*.bin
+*.bin
+
+# Local resume draft — contains plaintext PII; never deploy
+/static/resume-draft.html
 
 # Plaintext resumes — never commit; encrypted versions go to S3 instead
 /Brianjlogan.docx
 *.docx
 *.pdf
+/brianjlogan_*.html

--- a/static/js/resume-decrypt.js
+++ b/static/js/resume-decrypt.js
@@ -1,14 +1,22 @@
 // Decrypts a resume blob fetched from /encrypted-resumes/<id>.bin.
 //
-// Encrypted file layout (must match resume-tool.html):
-//   [magic:4 = "BRZ1"][salt:16][iv:12][AES-GCM ciphertext]
-// Decrypted plaintext layout:
-//   [mimeLen:1][mime:utf-8 mimeLen bytes][fnLen:1][filename:utf-8 fnLen bytes][file bytes]
+// Encrypted file layout (must match resume-tool.html, BRZ2 envelope):
+//   [magic:4 = "BRZ2"][salt:16][iv:12][AES-GCM ciphertext]
+//
+// Decrypted plaintext layout (multi-file bundle):
+//   [count:1]
+//   for each file:
+//     [mime_len:1][mime:utf-8][fn_len:1][fn:utf-8][size:4 BE][bytes:size]
+//
+// Routing by MIME after decrypt:
+//   text/html         → injected inline into #resume-default via innerHTML
+//   application/pdf   → download link + "open in new tab" link
+//   anything else     → download link only
 
 (function () {
     const ENCRYPTED_PATH = '/encrypted-resumes';
     const PBKDF2_ITERS = 250000;
-    const MAGIC = 'BRZ1';
+    const MAGIC = 'BRZ2';
 
     const statusEl = () => document.getElementById('resume-status');
     function status(msg, kind) {
@@ -33,14 +41,55 @@
         );
     }
 
-    function parsePlaintext(bytes) {
-        let off = 0;
-        const mimeLen = bytes[off]; off += 1;
-        const mime = new TextDecoder().decode(bytes.slice(off, off + mimeLen)); off += mimeLen;
-        const fnLen = bytes[off]; off += 1;
-        const filename = new TextDecoder().decode(bytes.slice(off, off + fnLen)); off += fnLen;
-        const file = bytes.slice(off);
-        return { mime, filename, file };
+    function parseBundle(bytes) {
+        const decoder = new TextDecoder();
+        const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const count = bytes[0];
+        let off = 1;
+        const files = [];
+        for (let i = 0; i < count; i++) {
+            const mimeLen = bytes[off]; off += 1;
+            const mime = decoder.decode(bytes.slice(off, off + mimeLen)); off += mimeLen;
+            const fnLen = bytes[off]; off += 1;
+            const filename = decoder.decode(bytes.slice(off, off + fnLen)); off += fnLen;
+            const size = dv.getUint32(off, false); off += 4;
+            const fileBytes = bytes.slice(off, off + size); off += size;
+            files.push({ mime, filename, bytes: fileBytes });
+        }
+        return files;
+    }
+
+    function renderBundle(files) {
+        const container = document.getElementById('resume-default');
+        const html = files.find(f => f.mime === 'text/html');
+        const pdf  = files.find(f => f.mime === 'application/pdf');
+        const others = files.filter(f => f !== html && f !== pdf);
+
+        // Toolbar at the top with download / open-in-tab actions for the PDF, plus
+        // any other (non-html, non-pdf) attachments as download links.
+        const links = [];
+        if (pdf) {
+            const pdfUrl = URL.createObjectURL(new Blob([pdf.bytes], { type: 'application/pdf' }));
+            links.push(
+                `<a href="${pdfUrl}" download="${pdf.filename}" style="color: var(--accent-cyan);">↓ download pdf</a>`,
+                `<a href="${pdfUrl}" target="_blank" rel="noopener" style="color: var(--accent-cyan);">↗ open pdf in new tab</a>`
+            );
+        }
+        for (const f of others) {
+            const url = URL.createObjectURL(new Blob([f.bytes], { type: f.mime || 'application/octet-stream' }));
+            links.push(`<a href="${url}" download="${f.filename}" style="color: var(--accent-cyan);">↓ download ${f.filename}</a>`);
+        }
+
+        const htmlFragment = html
+            ? new TextDecoder().decode(html.bytes)
+            : '<p style="color: var(--accent-yellow);">(no inline HTML in bundle)</p>';
+
+        container.innerHTML = `
+            <div style="display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--border-color);">
+                ${links.join('')}
+            </div>
+            ${htmlFragment}
+        `;
     }
 
     async function unlock(id, passcode) {
@@ -53,12 +102,12 @@
             return;
         }
         if (!resp.ok) {
-            status(`No resume found for that id.`, 'error');
+            status('No resume found for that id.', 'error');
             return;
         }
         const buf = new Uint8Array(await resp.arrayBuffer());
         if (buf.length < 32 || new TextDecoder().decode(buf.slice(0, 4)) !== MAGIC) {
-            status('File format not recognized.', 'error');
+            status('File format not recognized (expected BRZ2 bundle).', 'error');
             return;
         }
         const salt = buf.slice(4, 20);
@@ -77,20 +126,15 @@
             return;
         }
 
-        const { mime, filename, file } = parsePlaintext(new Uint8Array(plainBuf));
-        const blob = new Blob([file], { type: mime || 'application/octet-stream' });
-        const url  = URL.createObjectURL(blob);
+        let files;
+        try {
+            files = parseBundle(new Uint8Array(plainBuf));
+        } catch (e) {
+            status('Decrypted bundle is malformed.', 'error');
+            return;
+        }
 
-        const container = document.getElementById('resume-default');
-        container.innerHTML = `
-            <p style="color: var(--accent-green);">$ decrypted — ${filename}</p>
-            <p><a id="resume-download" download style="color: var(--accent-cyan);">↓ download</a></p>
-            <iframe id="resume-preview" src="${url}"
-                    style="width: 100%; height: 80vh; border: 1px solid var(--border-color); margin-top: 1rem; background: white;"></iframe>
-        `;
-        const dl = document.getElementById('resume-download');
-        dl.href = url;
-        dl.download = filename;
+        renderBundle(files);
         status('', 'ok');
     }
 

--- a/static/resume-tool.html
+++ b/static/resume-tool.html
@@ -59,16 +59,24 @@
 <body>
 <main>
     <h1>$ resume-encrypt</h1>
-    <p>Encrypts a file with AES-GCM (PBKDF2-SHA256, 250k iters) so it can be served from
-       <code>/encrypted-resumes/&lt;id&gt;.bin</code> and unlocked by the /resume page.</p>
+    <p>Bundles an HTML fragment + a PDF into one AES-256-GCM blob (PBKDF2-SHA256, 250k iters),
+       <code>BRZ2</code> envelope, ready to upload to
+       <code>/encrypted-resumes/&lt;id&gt;.bin</code>. The /resume page injects the HTML inline
+       and offers the PDF as a download.</p>
 
-    <h2>1. Pick file</h2>
+    <h2>1. HTML fragment (inline render)</h2>
     <label>
-        <span>file</span>
-        <input type="file" id="file">
+        <span>html file &mdash; just the inner content, no &lt;html&gt;/&lt;body&gt; wrappers</span>
+        <input type="file" id="html-file" accept=".html,.htm,text/html">
     </label>
 
-    <h2>2. Passcode</h2>
+    <h2>2. PDF (download link)</h2>
+    <label>
+        <span>pdf file &mdash; what recipients download for offline / print</span>
+        <input type="file" id="pdf-file" accept=".pdf,application/pdf">
+    </label>
+
+    <h2>3. Passcode</h2>
     <label>
         <span>passcode (leave blank to generate a random 12-char one)</span>
         <div class="row">
@@ -77,7 +85,7 @@
         </div>
     </label>
 
-    <h2>3. ID</h2>
+    <h2>4. ID</h2>
     <label>
         <span>id (used as the filename on S3; auto-generated if blank)</span>
         <div class="row">
@@ -86,15 +94,15 @@
         </div>
     </label>
 
-    <h2>4. Encrypt</h2>
+    <h2>5. Encrypt</h2>
     <button type="button" id="encrypt">$ encrypt</button>
     <p id="status" style="margin-top: 0.75rem; min-height: 1.2em;"></p>
 
     <div id="output">
         <div class="field">
-            <strong>encrypted file</strong>
+            <strong>encrypted bundle</strong>
             <a id="dl-link" download>↓ download &lt;id&gt;.bin</a>
-            <p style="margin: 0.25rem 0 0;">Place at <code>static/encrypted-resumes/&lt;id&gt;.bin</code> in the Zola repo (or upload directly to <code>s3://brianjlogan/encrypted-resumes/&lt;id&gt;.bin</code>).</p>
+            <p style="margin: 0.25rem 0 0;">Upload to <code>s3://brianjlogan/encrypted-resumes/&lt;id&gt;.bin</code> via <code>tools/upload-asset.sh &lt;path&gt; encrypted-resumes/&lt;id&gt;.bin --no-cache</code>.</p>
         </div>
         <div class="field">
             <strong>share URL</strong>
@@ -112,8 +120,14 @@
 </main>
 
 <script>
+// BRZ2 encrypted-file layout:
+//   [magic:4 "BRZ2"][salt:16][iv:12][AES-GCM ciphertext]
+// Decrypted plaintext layout (multi-file):
+//   [count:1]
+//   for each file:
+//     [mime_len:1][mime:utf-8][fn_len:1][fn:utf-8][size:4 BE][bytes:size]
 const PBKDF2_ITERS = 250000;
-const MAGIC = 'BRZ1';
+const MAGIC = 'BRZ2';
 
 function status(msg, kind) {
     const el = document.getElementById('status');
@@ -136,6 +150,14 @@ function regenId()   { document.getElementById('id').value       = randString(10
 document.getElementById('gen-pass').addEventListener('click', regenPass);
 document.getElementById('gen-id').addEventListener('click', regenId);
 
+function fileMime(file) {
+    if (file.type) return file.type;
+    const ext = file.name.split('.').pop().toLowerCase();
+    if (ext === 'html' || ext === 'htm') return 'text/html';
+    if (ext === 'pdf')                   return 'application/pdf';
+    return 'application/octet-stream';
+}
+
 async function deriveKey(passcode, salt) {
     const material = await crypto.subtle.importKey(
         'raw', new TextEncoder().encode(passcode),
@@ -149,24 +171,39 @@ async function deriveKey(passcode, salt) {
     );
 }
 
-function buildPlaintext(filename, mime, fileBytes) {
+// Build the BRZ2 plaintext envelope from an array of {filename, mime, bytes}.
+function buildBundle(files) {
     const enc = new TextEncoder();
-    const fnBytes = enc.encode(filename.slice(0, 255));
-    const mimeBytes = enc.encode((mime || 'application/octet-stream').slice(0, 255));
-    const out = new Uint8Array(1 + mimeBytes.length + 1 + fnBytes.length + fileBytes.length);
-    let off = 0;
-    out[off++] = mimeBytes.length;
-    out.set(mimeBytes, off); off += mimeBytes.length;
-    out[off++] = fnBytes.length;
-    out.set(fnBytes, off);   off += fnBytes.length;
-    out.set(fileBytes, off);
+    const parts = files.map(f => {
+        const fnBytes   = enc.encode(f.filename.slice(0, 255));
+        const mimeBytes = enc.encode((f.mime || 'application/octet-stream').slice(0, 255));
+        const size = f.bytes.length;
+        const buf = new Uint8Array(1 + mimeBytes.length + 1 + fnBytes.length + 4 + size);
+        let off = 0;
+        buf[off++] = mimeBytes.length;
+        buf.set(mimeBytes, off); off += mimeBytes.length;
+        buf[off++] = fnBytes.length;
+        buf.set(fnBytes, off);   off += fnBytes.length;
+        new DataView(buf.buffer, buf.byteOffset + off, 4).setUint32(0, size, false); off += 4;
+        buf.set(f.bytes, off);
+        return buf;
+    });
+    const total = 1 + parts.reduce((s, p) => s + p.length, 0);
+    const out = new Uint8Array(total);
+    out[0] = files.length;
+    let off = 1;
+    for (const p of parts) { out.set(p, off); off += p.length; }
     return out;
 }
 
 document.getElementById('encrypt').addEventListener('click', async () => {
-    const fileInput = document.getElementById('file');
-    const file = fileInput.files && fileInput.files[0];
-    if (!file) { status('Pick a file first.', 'err'); return; }
+    const htmlInput = document.getElementById('html-file');
+    const pdfInput  = document.getElementById('pdf-file');
+    const htmlFile  = htmlInput.files && htmlInput.files[0];
+    const pdfFile   = pdfInput.files  && pdfInput.files[0];
+
+    if (!htmlFile) { status('Pick an HTML file (step 1).', 'err'); return; }
+    if (!pdfFile)  { status('Pick a PDF file (step 2).',  'err'); return; }
 
     if (!document.getElementById('passcode').value) regenPass();
     if (!document.getElementById('id').value)       regenId();
@@ -177,8 +214,14 @@ document.getElementById('encrypt').addEventListener('click', async () => {
         status('ID must be URL-safe (letters, digits, _ or -).', 'err'); return;
     }
 
-    status('Reading file…');
-    const fileBytes = new Uint8Array(await file.arrayBuffer());
+    status('Reading files…');
+    const htmlBytes = new Uint8Array(await htmlFile.arrayBuffer());
+    const pdfBytes  = new Uint8Array(await pdfFile.arrayBuffer());
+
+    const files = [
+        { filename: htmlFile.name, mime: fileMime(htmlFile), bytes: htmlBytes },
+        { filename: pdfFile.name,  mime: fileMime(pdfFile),  bytes: pdfBytes  },
+    ];
 
     const salt = crypto.getRandomValues(new Uint8Array(16));
     const iv   = crypto.getRandomValues(new Uint8Array(12));
@@ -186,8 +229,8 @@ document.getElementById('encrypt').addEventListener('click', async () => {
     status('Deriving key…');
     const key = await deriveKey(passcode, salt);
 
-    status('Encrypting…');
-    const plain = buildPlaintext(file.name, file.type, fileBytes);
+    status('Encrypting bundle…');
+    const plain = buildBundle(files);
     const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plain));
 
     const magicBytes = new TextEncoder().encode(MAGIC);
@@ -214,7 +257,7 @@ document.getElementById('encrypt').addEventListener('click', async () => {
     document.getElementById('show-pass').textContent = passcode;
     document.getElementById('output').style.display  = 'block';
 
-    status('Done.', 'ok');
+    status(`Done. Bundled ${files.length} files into ${out.length.toLocaleString()} bytes.`, 'ok');
 });
 
 document.getElementById('copy-url').addEventListener('click', async () => {

--- a/themes/terminal/sass/style.scss
+++ b/themes/terminal/sass/style.scss
@@ -1056,3 +1056,180 @@ footer {
     }
   }
 }
+
+// ============================================================================
+// Resume layout primitives
+// Used by /resume (after decryption injects content) and the local draft
+// at /resume-draft.html. Class names are public but reveal no content.
+// ============================================================================
+
+.resume-header {
+  margin-bottom: 2rem;
+  // Neutralize the global `header { ... }` rules that target the tag selector
+  background: transparent;
+  border-bottom: none;
+  padding: 0;
+  animation: none;
+
+  h1 {
+    color: var(--accent-cyan);
+    margin-bottom: 0.5rem;
+    font-size: 1.6rem;
+  }
+
+  .resume-contact {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+
+    a { color: var(--accent-green); }
+  }
+
+  .resume-tagline {
+    color: var(--text-primary);
+    font-style: italic;
+    font-size: 1.1rem;
+  }
+}
+
+.resume-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2.5rem;
+  align-items: start;
+  font-size: 1.05rem;
+  line-height: 1.55;
+}
+
+.resume-section {
+  margin-bottom: 2rem;
+
+  h2 {
+    color: var(--accent-yellow);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.25rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1rem;
+  }
+}
+
+.resume-job {
+  margin-bottom: 1.5rem;
+
+  h3 {
+    color: var(--accent-cyan);
+    font-size: 1rem;
+    margin-bottom: 0.15rem;
+  }
+
+  .resume-meta {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+  }
+
+  ul {
+    margin-left: 1.2rem;
+    color: var(--text-primary);
+
+    li { margin-bottom: 0.3rem; }
+  }
+}
+
+.resume-aside {
+  ul.resume-skills {
+    list-style: none;
+    padding: 0;
+
+    li {
+      margin-bottom: 0.6rem;
+    }
+
+    strong { color: var(--accent-cyan); }
+  }
+}
+
+// Stack to a single column on narrow viewports
+@media (max-width: 768px) {
+  .resume-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+// Print: drop site chrome, switch to print-friendly colors, keep columns
+@media print {
+  @page {
+    size: letter;
+    margin: 0.5in;
+  }
+
+  // Kill all animations / transitions so print preview can't snapshot mid-frame
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  // body > header scopes to the site header only — the resume's own <header>
+  // (.resume-header) lives inside <main> and must stay visible.
+  body > header, footer, #crt-overlay, .vim-command-line, #shell-output, #autocomplete {
+    display: none !important;
+  }
+
+  // Force browsers to print accent colors as specified instead of stripping for ink-economy
+  body, .resume-header, .resume-section, .resume-job, .resume-aside {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body, .container { background: white !important; color: #111 !important; }
+  .container { padding: 0 !important; max-width: none !important; }
+
+  // Override the explicit `color: var(--text-primary)` set on these in screen mode
+  // (which would render as near-white on the white print background).
+  .resume-job ul,
+  .resume-header .resume-tagline,
+  .resume-aside ul.resume-skills,
+  .resume-aside p { color: #111 !important; }
+
+  // Accent color — single dark cyan that's legible on white and echoes the site's cyan
+  .resume-header h1,
+  .resume-section h2,
+  .resume-job h3,
+  .resume-aside ul.resume-skills strong {
+    color: #0a4f7a !important;
+  }
+  .resume-section h2 { border-color: #c0c0c0 !important; }
+
+  // Meta / muted text — dark enough to read on white
+  .resume-meta,
+  .resume-header .resume-contact { color: #444 !important; }
+
+  // Links: contact mailto picks up the accent; other links go plain black
+  a { color: #111 !important; text-decoration: none; }
+  .resume-header .resume-contact a { color: #0a4f7a !important; }
+
+  // Keep two-column layout in print, tighter gap
+  .resume-grid { grid-template-columns: 2fr 1fr !important; gap: 1.5rem; }
+
+  // Page break management — allow long jobs (esp. SRE) to flow naturally across
+  // pages. widows/orphans prevent ugly 1-2 line splits without demanding that
+  // every article fit on a single page (which would push long jobs to a fresh
+  // page and leave the prior one mostly empty).
+  .resume-job { orphans: 3; widows: 3; }
+
+  // Never split an individual bullet or paragraph across a page boundary
+  li, p { break-inside: avoid; page-break-inside: avoid; }
+
+  // Headings stay glued to the content on either side: `break-after: avoid`
+  // stops a heading from being orphaned at the bottom of a page, and
+  // `break-before: avoid` stops a page break from landing between the end of
+  // the previous paragraph and the heading that follows it.
+  .resume-job h3,
+  .resume-section h2 {
+    break-after: avoid; page-break-after: avoid;
+    break-before: avoid; page-break-before: avoid;
+  }
+
+  .page-break-before { break-before: page; page-break-before: always; }
+}


### PR DESCRIPTION
## Summary
- **BRZ2 envelope** — multi-file encrypted bundle so recipients see an inline HTML rendering of the resume plus a downloadable PDF, all from one share link / one passcode.
  - Encrypted layout: \`[magic:4 'BRZ2'][salt:16][iv:12][AES-GCM ciphertext]\`
  - Plaintext bundle: \`[count:1]\` then N records of \`[mime_len:1][mime][fn_len:1][fn][size:4 BE][bytes]\`
  - \`resume-tool.html\`: two file inputs (HTML + PDF), builds BRZ2 envelope
  - \`resume-decrypt.js\`: parses BRZ2, routes by MIME — \`text/html\` injects inline into \`#resume-default\` via \`innerHTML\` (inherits site styling), \`application/pdf\` becomes download + open-in-new-tab links, anything else becomes a download link
- **Resume CSS primitives** in \`style.scss\`: \`.resume-grid\` (2-col, collapses to 1-col under 768px), \`.resume-header\`, \`.resume-section\`, \`.resume-job\`, \`.resume-aside\`, \`.resume-skills\`. Font sizes bumped for readability.
- **Print refinements**:
  - \`@page\` letter / 0.5in margins
  - \`print-color-adjust: exact\` so accent colors survive ink-saving optimizations
  - Dark cyan (\`#0a4f7a\`) accents for headings / skill labels; near-black \`#111\` body text
  - All \`animation\` / \`transition\` disabled in print so preview can't snapshot mid-frame
  - Site \`<header>\` animation neutralized on \`.resume-header\` (was leaking via the tag selector); print scoping switched to \`body > header\` so the resume's own header stays visible
  - Page-break controls: never split a paragraph/bullet mid-way, never break between end-of-paragraph and next heading, \`widows/orphans: 3\` on \`.resume-job\`
  - \`.page-break-before\` class for explicit forced breaks
- **\`.gitignore\`** broadened to keep plaintext out: \`*.docx\`, \`*.pdf\`, \`*.bin\` everywhere; \`/brianjlogan_*.html\` for the local HTML fragment source.

## Test plan
- [x] Local: encrypted bundle uploaded to \`s3://brianjlogan/encrypted-resumes/m6bmjJyvKU.bin\`, decrypts cleanly via \`zola serve\` → \`/resume/#m6bmjJyvKU.<passcode>\`
- [x] Local: HTML fragment renders inline inheriting site styles, PDF link opens browser-native viewer in new tab
- [x] Local: print preview shows two columns, dark-cyan accents, no animation artifacts, forced page break before VirTech entry
- [ ] After merge: hit production share URL, verify decrypt against the live \`/encrypted-resumes/m6bmjJyvKU.bin\`

## Notes
- The earlier BRZ1 blob (\`p67QWaSs8A.bin\`) is no longer decryptable — the new JS only understands BRZ2. Fine since the active blob is the BRZ2 \`m6bmjJyvKU.bin\`.
- S3 versioning is on, so the BRZ1 blob is preserved as a prior version if ever needed.